### PR TITLE
Handle LexisNexis giving us an error 'document' instead of an article

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ env:
 before_install:
   - cd $TEST_DIR
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+
+services:
+  - xvfb
 
 addons:
   apt:

--- a/tm.plugin.lexisnexis/R/LexisNexisSource.R
+++ b/tm.plugin.lexisnexis/R/LexisNexisSource.R
@@ -21,6 +21,15 @@ LexisNexisSource <- function(x, encoding = "UTF-8") {
     # Get rid of short empty sections
     content <- content[nchar(content) > 200]
 
+    # If LexisNexis has generated an error 'document' then we won't be able to handle it; warn and drop
+    errtexts <- grepl("We are sorry but there is an error in this document and it is not possible to display it.",
+                      content,
+                      fixed=TRUE)
+    if(any(errtexts)) {
+        warning(paste0(x, ": LexisNexis failed to provide some documents; skipping number(s)", as.character(which(errtexts)), "\n", collapse=""))
+        content <- content[!errtexts]
+    }
+
     SimpleSource(encoding, length(content),
                  content=content, uri=x,
                  reader=readLexisNexisHTML, class="LexisNexisSource")

--- a/tm.plugin.lexisnexis/R/LexisNexisSource.R
+++ b/tm.plugin.lexisnexis/R/LexisNexisSource.R
@@ -26,7 +26,8 @@ LexisNexisSource <- function(x, encoding = "UTF-8") {
                       content,
                       fixed=TRUE)
     if(any(errtexts)) {
-        warning(paste0(x, ": LexisNexis failed to provide some documents; skipping number(s) ", paste0(which(errtexts), collapse=" "), "\n", collapse=""))
+        warning(x, ": LexisNexis failed to provide some documents; skipping number(s) ",
+                paste0(which(errtexts), collapse=", "))
         content <- content[!errtexts]
     }
     

--- a/tm.plugin.lexisnexis/R/LexisNexisSource.R
+++ b/tm.plugin.lexisnexis/R/LexisNexisSource.R
@@ -26,10 +26,10 @@ LexisNexisSource <- function(x, encoding = "UTF-8") {
                       content,
                       fixed=TRUE)
     if(any(errtexts)) {
-        warning(paste0(x, ": LexisNexis failed to provide some documents; skipping number(s)", as.character(which(errtexts)), "\n", collapse=""))
+        warning(paste0(x, ": LexisNexis failed to provide some documents; skipping number(s) ", paste0(which(errtexts), collapse=" "), "\n", collapse=""))
         content <- content[!errtexts]
     }
-
+    
     SimpleSource(encoding, length(content),
                  content=content, uri=x,
                  reader=readLexisNexisHTML, class="LexisNexisSource")

--- a/tm.plugin.lexisnexis/R/readLexisNexisHTML.R
+++ b/tm.plugin.lexisnexis/R/readLexisNexisHTML.R
@@ -56,7 +56,13 @@ readLexisNexisHTML <- FunctionGenerator(function(elem, language, id) {
         names(nodes) <- sapply(nodes, function(x) xml_text(xml_children(xml_children(x)[[1]])[1], trim=TRUE))
         vals <- sapply(nodes, xml_text, trim=TRUE)
 
-        copyright <- vals[[max(which(grepl("^Copyright", vals)))]]
+        cr <- which(grepl("^Copyright", vals))
+        if (any(cr)) {
+            copyright <- vals[[max(cr)]]
+        } else {
+            warning(sprintf("Could not parse copyright notice for article %s. This may indicate a problem with the source data, as LexisNexis copyright notices are nearly universal.\n", id))
+            copyright=NULL
+        }
 
         # First item is the document number
         publication <- vals[2]

--- a/tm.plugin.lexisnexis/R/readLexisNexisHTML.R
+++ b/tm.plugin.lexisnexis/R/readLexisNexisHTML.R
@@ -61,7 +61,7 @@ readLexisNexisHTML <- FunctionGenerator(function(elem, language, id) {
             copyright <- vals[[max(cr)]]
         } else {
             warning(sprintf("Could not parse copyright notice for article %s. This may indicate a problem with the source data, as LexisNexis copyright notices are nearly universal.\n", id))
-            copyright=NULL
+            copyright <- NULL
         }
 
         # First item is the document number

--- a/tm.plugin.lexisnexis/inst/texts/lexisnexis_test_copyright_error.html
+++ b/tm.plugin.lexisnexis/inst/texts/lexisnexis_test_copyright_error.html
@@ -1,0 +1,128 @@
+<HTML>
+<HEAD>
+<STYLE TYPE="text/css"><!--
+.c0 { text-align: center; }
+.c1 { text-align: center; margin-top: 0em; margin-bottom: 0em; }
+.c2 { font-family: Arial; font-size: 10pt; font-style: normal; font-weight: normal; color: #000000; text-decoration: none; }
+.c3 { text-align: center; margin-left: 13%; margin-right: 13%; }
+.c4 { font-family: Arial; font-size: 10pt; font-style: normal; font-weight: bold; color: #CC0033; text-decoration: none; }
+.c5 { text-align: left; }
+.c6 { text-align: left; margin-top: 0em; margin-bottom: 0em; }
+.c7 { font-family: Arial; font-size: 14pt; font-style: normal; font-weight: bold; color: #000000; text-decoration: none; }
+.c8 { font-family: Arial; font-size: 10pt; font-style: normal; font-weight: bold; color: #000000; text-decoration: none; }
+.c9 { text-align: left; margin-top: 1em; margin-bottom: 0em; }
+.c10 { font-family: Arial; font-size: 14pt; font-style: normal; font-weight: bold; color: #CC0033; text-decoration: none; }
+.c11 { border-collapse: collapse; table-layout: auto; width:100%; }
+.c12 { width: 132pt; }
+.c13 { width: 30pt; }
+.c14 { text-align: left; vertical-align: top; padding-left: 2pt; padding-right: 2pt; }
+.c15 { width: 66pt; }
+.c16 { width: 138pt; }
+.c17 { width: 60pt; }
+.c18 { width: 84pt; }
+.c19 { width: 78pt; }
+.c20 { width: 36pt; }
+.c21 { width: 108pt; }
+.c22 { width: 72pt; }
+.c23 { width: 48pt; }
+.c24 { width: 54pt; }
+.c25 { width: 174pt; }
+.c26 { width: 114pt; }
+.c27 { font-family: 'Courier New',Courier; font-size: 10pt; font-style: normal; font-weight: normal; color: #000000; text-decoration: none; }
+.c28 { page-break-before: always; }
+--></STYLE>
+<TITLE>&nbsp;</TITLE>
+<META TOPIC="null" DOCUMENTS="2" UPDATED="Tuesday, October 15, 2019  23:59:59" /></HEAD>
+<BODY>
+<DIV CLASS="c5"><P CLASS="c6"><style> 
+ .resize { 
+ width:auto; max-width:37.5em;max-height:50em
+;height:auto;  
+ } 
+ </style><IMG class= "resize" SRC="https://www.nexis.com/images/GBNexisLogo.gif" ALT="https://www.nexis.com/images/GBNexisLogo.gif"><BR><BR><BR><SPAN CLASS="c27">Download Request: Selected Items: 1-2<BR>Time Of Request: Tuesday, October 15, 2019 &nbsp;23:59:59<BR><BR>Send To:<BR><BR>WALDEN COLLEGE<BR>POND ST<BR>NEW HAVEN, CT 06520<BR><BR><BR>Terms: bank<BR><BR><BR>Source: The Daily Planet<BR>Project ID: <BR><BR></SPAN></P>
+</DIV>
+<DIV CLASS="c28">&nbsp;</DIV>
+<A NAME="DOC_ID_1_0"></A><!-- Hide XML section from browser
+<DOC NUMBER=1>
+<DOCFULL> -->
+<BR><DIV CLASS="c0"><P CLASS="c1"><SPAN CLASS="c2">1 of 2 DOCUMENTS</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c0"><BR><P CLASS="c1"><style> 
+ .resize { 
+ width:auto; max-width:37.5em;max-height:50em
+;height:auto;  
+ } 
+ </style><BR><SPAN CLASS="c2">The Daily Planet</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c3"><P CLASS="c1"><SPAN CLASS="c4">December</SPAN><SPAN CLASS="c2"> 31, 2018 Monday</SPAN><SPAN CLASS="c2">&nbsp;</SPAN><SPAN CLASS="c2">&nbsp;<BR>City Final Edition</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c8">SECTION: </SPAN><SPAN CLASS="c2">Pg. B22</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c8">LENGTH: </SPAN><SPAN CLASS="c2">44 words</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c5"><BR></DIV>
+<TABLE CLASS="c11">
+<TR><TD WIDTH="8.22%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Rank</SPAN></P>
+</TD><TD WIDTH="24.66%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c4">Bank</SPAN></P>
+</TD><TD WIDTH="16.44%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">City</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Branches</SPAN></P>
+</TD><TD WIDTH="10.96%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Deposits (billions)</SPAN></P>
+</TD><TD WIDTH="12.33%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Market share</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Local employees</SPAN></P>
+</TD></TR>
+<TR><TD WIDTH="8.22%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">1</SPAN></P>
+</TD><TD WIDTH="24.66%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Megabank One</SPAN></P>
+</TD><TD WIDTH="16.44%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">London</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">444</SPAN></P>
+</TD><TD WIDTH="10.96%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">44.4</SPAN></P>
+</TD><TD WIDTH="12.33%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">44.4</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">4,444</SPAN></P>
+</TD></TR>
+<TR><TD WIDTH="8.22%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">2</SPAN></P>
+</TD><TD WIDTH="24.66%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Octopus Financial</SPAN></P>
+</TD><TD WIDTH="16.44%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Frankfurt</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">333</SPAN></P>
+</TD><TD WIDTH="10.96%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">33.3</SPAN></P>
+</TD><TD WIDTH="12.33%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">33.3</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">3,333</SPAN></P>
+</TD></TR>
+<TR><TD WIDTH="8.22%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">3</SPAN></P>
+</TD><TD WIDTH="24.66%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Bank of Gotham</SPAN></P>
+</TD><TD WIDTH="16.44%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">New York</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">222</SPAN></P>
+</TD><TD WIDTH="10.96%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">22.2</SPAN></P>
+</TD><TD WIDTH="12.33%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">22.2</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">2,222</SPAN></P>
+</TD></TR>
+<TR><TD WIDTH="8.22%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">4</SPAN></P>
+</TD><TD WIDTH="24.66%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">HKBC</SPAN></P>
+</TD><TD WIDTH="16.44%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">Hong Kong</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">111</SPAN></P>
+</TD><TD WIDTH="10.96%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">11.1</SPAN></P>
+</TD><TD WIDTH="12.33%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">11.1</SPAN></P>
+</TD><TD WIDTH="13.7%" CLASS="c14"><P CLASS="c6"><SPAN CLASS="c2">1,111</SPAN></P>
+</TD></TR>
+</TABLE>
+</DIV>
+<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c8">LOAD-DATE: </SPAN><SPAN CLASS="c2">December 31, 2018</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c8">LANGUAGE: </SPAN><SPAN CLASS="c2">ENGLISH</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c8">DISTRIBUTION: </SPAN><SPAN CLASS="c2">Every Zone</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c8">PUBLICATION-TYPE: </SPAN><SPAN CLASS="c2">Newspaper</SPAN></P>
+</DIV>
+<BR><DIV CLASS="c0"><BR><P CLASS="c1"><SPAN CLASS="c2">Copy 2013 The Daily Planet<BR>All Rights Reserved</SPAN></P>
+</DIV>
+<!-- Hide XML section from browser
+</DOCFULL>
+</DOC> -->
+<A NAME="DOC_ID_2_0"></A><!-- Hide XML section from browser
+<DOC NUMBER=1>
+<DOCFULL> -->
+<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c2">We are sorry but there is an error in this document and it is not possible to display it.</SPAN></P>
+</DIV>
+<!-- Hide XML section from browser
+</DOCFULL>
+</DOC> -->
+</BODY></HTML>

--- a/tm.plugin.lexisnexis/tests/import.R
+++ b/tm.plugin.lexisnexis/tests/import.R
@@ -10,3 +10,13 @@ corpus <- Corpus(LexisNexisSource(file))
 file <- system.file("texts", "lexisnexis_test_fr.html",
                     package = "tm.plugin.lexisnexis")
 corpus <- Corpus(LexisNexisSource(file))
+
+# Two malformed examples: one which can be parsed but with a missing copyright
+# notice (and with a warning), and one which should be dropped (with a warning).
+# We suppress warnings to avoid breaking the build, then test the consequences.
+file <- system.file("texts", "lexisnexis_test_copyright_error.html",
+                    package = "tm.plugin.lexisnexis")
+corpus <- suppressWarnings(Corpus(LexisNexisSource(file)))
+stopifnot(length(corpus) == 1,
+          corpus[[1]]$meta$id == "resize201812311",
+          length(corpus[[1]]$meta$rights) == 0)


### PR DESCRIPTION
Under some circumstances LexisNexis provides an error message as one of the documents in a downloaded file. The offending section of the file looks like the following:
```
<A NAME="DOC_ID_169_0"></A><!-- Hide XML section from browser
<DOC NUMBER=1>
<DOCFULL> -->
<BR><DIV CLASS="c5"><P CLASS="c6"><SPAN CLASS="c2">We are sorry but there is an error in this document and it is not possible to display it.</SPAN></P>
</DIV>
<!-- Hide XML section from browser
</DOCFULL>
</DOC> -->
```
This causes the whole file to fail; `readLexisNexisHTML()` raises an error as it can't find a copyright string.

This patch amends `LexisNexisSource()` to check for the error message and drop the failed document with a warning.

The test is currently localised only to English as I don't know what the appropriate message is in other languages. An alternative approach would be to handle the no-copyright-notice case in `readLexisNexisHTML()` (which would catch a wider variety of malformed documents) but I think then the only option would be to feed an empty `PlainTextDocument` into the corpus, which is undesirable.

Edit: There turned out to be one document in my corpus that had a malformed copyright statement even without this error, so I've added a second patch to handle this case with a warning.