### PR TITLE
Fix tm.plugin.factiva metadata handling bugs

### DIFF
--- a/tm.plugin.factiva/R/readFactivaHTML.R
+++ b/tm.plugin.factiva/R/readFactivaHTML.R
@@ -39,17 +39,9 @@ readFactivaHTML <- FunctionGenerator(function(elem, language, id) {
         }
 
         data[["AN"]] <- gsub("Document ", "", data[["AN"]])
+        id <- if(!is.na(data[["AN"]])) data[["AN"]] else paste(sample(LETTERS, 10), collapse="")
 
         wc <- as.integer(regmatches(data[["WC"]], regexpr("^[[:digit:]]+", data[["WC"]])))[[1]]
-
-        # Extract useful information: origin, date, and code
-        m <- regmatches(data[["AN"]], regexec("^([A-Za-z]+)0*[1-9][0-9]([0-9][0-9][0-3][0-9][0-3][0-9])([A-Za-z0-9])",
-                                              data[["AN"]]))[[1]]
-        # If extraction failed for some reason, make sure we return a unique identifier
-        if(length(m) == 4)
-            id <- paste(toupper(m[2]), "-", m[3], "-", m[4], sep="")
-        else
-            id <- paste(sample(LETTERS, 10), collapse="")
 
         subject <- if(!is.na(data[["NS"]])) strsplit(data[["NS"]], "( \\| )")[[1]]
                    else character(0)

--- a/tm.plugin.factiva/R/readFactivaHTML.R
+++ b/tm.plugin.factiva/R/readFactivaHTML.R
@@ -40,9 +40,6 @@ readFactivaHTML <- FunctionGenerator(function(elem, language, id) {
 
         data[["AN"]] <- gsub("Document ", "", data[["AN"]])
 
-        pg <- if(is.na(data[["PG"]][[1]])) NA
-              else as.integer(regmatches(data[["PG"]], regexpr("^[[:digit:]]+", data[["PG"]])))[[1]]
-
         wc <- as.integer(regmatches(data[["WC"]], regexpr("^[[:digit:]]+", data[["WC"]])))[[1]]
 
         # Extract useful information: origin, date, and code
@@ -106,7 +103,7 @@ readFactivaHTML <- FunctionGenerator(function(elem, language, id) {
         meta(doc, "industry") <- industry
         meta(doc, "infocode") <- infocode
         meta(doc, "infodesc") <- infodesc
-        meta(doc, "page") <- pg
+        meta(doc, "page") <- if(!is.na(data[["PG"]])) data[["PG"]] else character(0)
         meta(doc, "wordcount") <- wc
         meta(doc, "publisher") <- if(!is.na(data[["PUB"]])) data[["PUB"]] else character(0)
         meta(doc, "rights") <- if(!is.na(data[["CY"]])) data[["CY"]] else character(0)


### PR DESCRIPTION
These patches fix two issues with `tm.plugin.factiva` which can cause input failure in some cases. It does so by slightly simplifying metadata handling in `readFactivaHTML`.

The first issue is newspapers with alphanumeric page numbering (e.g. The Wall Street Journal pg. A6). The existing code attempted to strip out the alphabetic parts, which are meaningful for these papers, and also caused an error if the value was not `NA` but had no numeric part to extract, preventing ingestion.

The second issue is the handling of the "AN" (Accession Number) field. This is unique in Factiva, but the existing code attempts to extract the useful parts to construct a shorter ID, in such a way that this may no longer be unique especially if a large numbers of articles from the same day are being ingested. For example, the following different articles all get the same id (`j-070102-e`):

- `Document J000000020070102e31200002`
- `Document J000000020070102e31200007`
- `Document J000000020070102e31200009`

This causes the resulting corpus to be incorrect; of those articles with identical ids, one will have multiple copies and the others missing. I can't construct an algorithm which is provably valid for all AN fields and which continues to extract only the useful parts, so the bug is fixed here by simply using the original AN field (less the leading "Document ") directly.

Note that the first fix changes `typeof(meta(x, "page"))` from double to character, which may not be compatible with all downstream uses.